### PR TITLE
Fix compilation on platforms that don't use i8 for c_char

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuzzyhash"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Russ Morris <rustysec@gmail.com>"]
 license = "MIT"
 description = "Pure Rust fuzzy hash implementation"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ use hasher::Hasher;
 use std::ffi::{CStr, CString};
 use std::fmt;
 use std::path::Path;
+use std::os::raw::c_char;
 
 /// Result of fuzzy hash operations
 pub type Result<T> = std::result::Result<T, error::Error>;
@@ -238,7 +239,7 @@ impl From<String> for FuzzyHash {
 ///
 /// ```
 #[no_mangle]
-pub unsafe extern "C" fn fuzzyhash(buf: *const u8, length: usize) -> *mut i8 {
+pub unsafe extern "C" fn fuzzyhash(buf: *const u8, length: usize) -> *mut c_char {
     let data = std::slice::from_raw_parts(buf, length);
     let mut fuzzy_hash = FuzzyHash::new(data);
     fuzzy_hash.finalize();
@@ -270,7 +271,7 @@ pub unsafe extern "C" fn fuzzyhash(buf: *const u8, length: usize) -> *mut i8 {
 /// assert_eq!(compared, 17);
 /// ```
 #[no_mangle]
-pub unsafe extern "C" fn fuzzyhash_compare(first: *const i8, second: *const i8) -> u32 {
+pub unsafe extern "C" fn fuzzyhash_compare(first: *const c_char, second: *const c_char) -> u32 {
     let f = FuzzyHash::new(CStr::from_ptr(first).to_string_lossy().into_owned());
     let s = FuzzyHash::new(CStr::from_ptr(second).to_string_lossy().into_owned());
 


### PR DESCRIPTION
closes #9 

* Fix compilation on platforms that don't use i8 for c_char

This commit makes use of a c_char type instead of an
i8. On x86 platforms i8 == c_char, but it can also be u8 on other
platforms. [1][2] This should fix compilation on those platforms by just
using the c_char type so that we're using the right type regardless
of which platform is being built for.

[1] https://doc.rust-lang.org/std/os/raw/type.c_char.html
[2] https://github.com/rust-lang/rust/blob/master/library/std/src/os/raw/mod.rs#L55-L99

Credit for all the legwork: @HenryHoggard